### PR TITLE
add integration test for java-library plugin

### DIFF
--- a/src/test/groovy/io/franzbecker/gradle/lombok/AbstractIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/AbstractIntegrationTest.groovy
@@ -75,4 +75,61 @@ abstract class AbstractIntegrationTest extends Specification {
         return file
     }
 
+    protected void createSimpleTestCase() {
+        // build configuration supporting JUnit
+        buildFile << """
+            dependencies {
+                testCompile 'junit:junit:4.12'
+            }
+        """.stripIndent()
+
+        // source code to compile and test
+        createJavaSource()
+        createTestSource()
+    }
+
+    private void createJavaSource() {
+        def file = createFile("src/main/java/com/example/HelloWorld.java")
+        file << """\
+            package com.example;
+
+            import lombok.Data;
+
+            @Data
+            public class HelloWorld {
+
+                private String id;
+
+            }
+        """.stripIndent()
+    }
+
+    private void createTestSource() {
+        def file = createFile("src/test/java/com/example/HelloWorldTest.java")
+        file << """\
+            package com.example;
+
+            import java.util.UUID;
+            import org.junit.Test;
+            import org.junit.Assert;
+
+            public class HelloWorldTest {
+
+                @Test
+                public void testHelloWorld() {
+                    // Given
+                    HelloWorld obj = new HelloWorld();
+                    String id = UUID.randomUUID().toString();
+
+                    // When
+                    obj.setId(id);
+
+                    // Then
+                    Assert.assertEquals(id, obj.getId());
+                }
+
+            }
+        """.stripIndent()
+    }
+
 }

--- a/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -15,19 +15,9 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
     }
 
     def "Gradle #gradleVersion - can compile and test @Data annotation"() {
-        given: "a specific Gradle version"
+        given:
         theGradleVersion = gradleVersion
-
-        and: "a build configuration supporting JUnit"
-        buildFile << """
-            dependencies {
-                testCompile 'junit:junit:4.12'
-            }
-        """.stripIndent()
-
-        and: "source code to compile and test"
-        createJavaSource()
-        createTestSource()
+        createSimpleTestCase()
 
         when: "calling gradle test"
         runBuild('test')
@@ -44,50 +34,6 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         '2.14.1'      || 'build/classes'
         '3.5'         || 'build/classes'
         '4.2.1'       || 'build/classes/java'
-    }
-
-    private void createJavaSource() {
-        def file = createFile("src/main/java/com/example/HelloWorld.java")
-        file << """
-            package com.example;
-
-            import lombok.Data;
-
-            @Data
-            public class HelloWorld {
-
-                private String id;
-
-            }
-        """.stripIndent()
-    }
-
-    private void createTestSource() {
-        def file = createFile("src/test/java/com/example/HelloWorldTest.java")
-        file << """
-            package com.example;
-
-            import java.util.UUID;
-            import org.junit.Test;
-            import org.junit.Assert;
-
-            public class HelloWorldTest {
-
-                @Test
-                public void testHelloWorld() {
-                    // Given
-                    HelloWorld obj = new HelloWorld();
-                    String id = UUID.randomUUID().toString();
-
-                    // When
-                    obj.setId(id);
-
-                    // Then
-                    Assert.assertEquals(id, obj.getId());
-                }
-
-            }
-        """.stripIndent()
     }
 
 }

--- a/src/test/groovy/io/franzbecker/gradle/lombok/LombokPluginIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/LombokPluginIntegrationTest.groovy
@@ -41,6 +41,20 @@ class LombokPluginIntegrationTest extends AbstractIntegrationTest {
         new File(projectDir, "build/classes/java/test/com/example/SneakyHelloWorldTest.class").exists()
     }
 
+    def "Works with the java-library plugin"() {
+        given:
+        buildFile.text = buildFile.text.replace("id 'java'", "id 'java-library'")
+        createSimpleTestCase()
+
+        when:
+        runBuild('test')
+
+        then:
+        noExceptionThrown()
+        new File(projectDir, "build/classes/java/main/com/example/HelloWorld.class").exists()
+        new File(projectDir, "build/classes/java/test/com/example/HelloWorldTest.class").exists()
+    }
+
     /**
      * Verifies that the Lombok dependency does not occur in the generated POM.
      */

--- a/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskIntegrationTest.groovy
@@ -26,7 +26,7 @@ class DelombokTaskIntegrationTest extends AbstractIntegrationTest {
 
     def "Delombok on directory produced proper output"() {
         given:
-        createJavaSource()
+        createSourceForDelombok()
 
         and:
         buildFile << """
@@ -63,7 +63,7 @@ class DelombokTaskIntegrationTest extends AbstractIntegrationTest {
         contents.contains("public String getId() {")
     }
 
-    private void createJavaSource() {
+    private void createSourceForDelombok() {
         def file = createFile("src/main/java/com/example/HelloWorld.java")
         file << """
             package com.example;


### PR DESCRIPTION
Add integration test to verify that the plugin works when the java-library plugin is applied (see #24).