### PR TITLE
Use annotationProcessor on Gradle 4.6 and later

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.12
+version=1.13

--- a/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
+++ b/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
@@ -8,6 +8,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.idea.IdeaPlugin
+import org.gradle.util.GradleVersion
 
 /**
  * Plugin for project Lombok support.
@@ -57,8 +58,16 @@ class LombokPlugin implements Plugin<Project> {
             )
         }
 
-        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
-        compile.extendsFrom(configuration)
+        if (GradleVersion.version(project.gradle.gradleVersion).compareTo(GradleVersion.version('4.6')) < 0) {
+            project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+            project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+        } else {
+            project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+            project.configurations.getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME).extendsFrom(configuration)
+            project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
+            project.configurations.getByName(JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME).extendsFrom(configuration)
+        }
+
         return configuration
     }
 

--- a/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -29,11 +29,11 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
 
         where:
         gradleVersion || classesPath
-        '2.11'        || 'build/classes'
         '2.12'        || 'build/classes'
         '2.14.1'      || 'build/classes'
         '3.5'         || 'build/classes'
         '4.2.1'       || 'build/classes/java'
+        '4.6'         || 'build/classes/java'
     }
 
 }


### PR DESCRIPTION
To solve the deprecation warning on Gradle 4.6 and later, conditional setup codes are added.