### PR TITLE
Fixed issue #38

### DIFF
--- a/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
+++ b/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
@@ -58,12 +58,12 @@ class LombokPlugin implements Plugin<Project> {
             )
         }
 
-        project.configurations.getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
-        project.configurations.getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME).extendsFrom(configuration)
         boolean atLeastGradle4_6 = GradleVersion.version(project.gradle.gradleVersion) >= GradleVersion.version('4.6')
         if (atLeastGradle4_6) {
+            project.configurations.getByName(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME).extendsFrom(configuration)
             project.configurations.getByName(JavaPlugin.ANNOTATION_PROCESSOR_CONFIGURATION_NAME).extendsFrom(configuration)
-            project.configurations.getByName(JavaPlugin.TEST_ANNOTATION_PROCESSOR_CONFIGURATION_NAME).extendsFrom(configuration)
+        } else {
+            project.configurations.getByName("compile" /* JavaPlugin.COMPILE_CONFIGURATION_NAME */).extendsFrom(configuration)
         }
 
         return configuration

--- a/src/test/groovy/io/franzbecker/gradle/lombok/LombokPluginIntegrationTest.groovy
+++ b/src/test/groovy/io/franzbecker/gradle/lombok/LombokPluginIntegrationTest.groovy
@@ -130,7 +130,7 @@ class LombokPluginIntegrationTest extends AbstractIntegrationTest {
 
         and: "verify the lombok JAR is included"
         def module = new XmlSlurper().parse(imlFile)
-        def provided = module.component.orderEntry.find { it.@scope == "PROVIDED" }
+        def provided = module.component.orderEntry.find { it.@type == "module-library" }
         assert provided
         def lombokEntry = provided.library.CLASSES.root.find { it.@url.text().contains("lombok-${LOMBOK_VERSION}.jar") }
         assert lombokEntry


### PR DESCRIPTION
 Fixed issue #38 

- Use "implementation" instead of "compileOnly"
- Removed unnecessary TEST_*_CONFIGURATION_NAMEs
- Fixed test case (It seems broken. Right?)

I'm not sure about second item but I removed these because these were unnecessary in my test. Please add them back if you think we need to keep them.

I've tested them on gradle 4.5, 4.6 with IntelliJ idea CE 2018.1.