### PR TITLE
Fix `DelombokTask` to work with modern Gradle dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 Please feel free to contribute using pull requests.
-All contributions must be licensed under the [Apache License 2.0](LICSENSE) or compatible.
+All contributions must be licensed under the [Apache License 2.0](LICENSE) or compatible.
 
 ## Testing IDEs locally
 
@@ -9,7 +9,7 @@ All features should be covered by unit and integration tests.
 Still, since we don't have automated IDE tests it might be necessary to test your contribution
 manually for IDE compatibility.
 
-Perform the following Gradle commadn to publish the plugin to your local Maven repository:
+Perform the following Gradle command to publish the plugin to your local Maven repository:
 
 ```
 ./gradlew publishToMavenLocal
@@ -23,7 +23,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'io.franzbecker:gradle-lombok:1.+'
+        classpath 'io.franzbecker:gradle-lombok:+'
     }
 }
 

--- a/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/DelombokTask.groovy
+++ b/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/DelombokTask.groovy
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.JavaExec
 class DelombokTask extends JavaExec {
 
     @Input
-    String compileConfigurationName = JavaPlugin.COMPILE_CONFIGURATION_NAME
+    String compileConfigurationName = JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME
 
     DelombokTask() {
         super()
@@ -24,12 +24,11 @@ class DelombokTask extends JavaExec {
     void exec() {
         // Retrieve extension and configuration
         def extension = project.extensions.findByType(LombokPluginExtension)
-        def lombok = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
         def compile = project.configurations.getByName(compileConfigurationName)
 
         // Configure JavaExec
         setMain(extension.main)
-        classpath(lombok, compile)
+        classpath(compile)
         super.exec()
     }
 

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -34,6 +34,7 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         '3.5'         || 'build/classes'
         '4.2.1'       || 'build/classes/java'
         '4.7'         || 'build/classes/java'
+        '5.4'         || 'build/classes/java'
     }
 
 }

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/AbstractJavaExecTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/AbstractJavaExecTaskSpec.groovy
@@ -14,13 +14,11 @@ import spock.lang.Specification
 abstract class AbstractJavaExecTaskSpec extends Specification {
 
     Project project
-    Configuration configuration
 
     void setup() {
         project = ProjectBuilder.builder().build()
         project.apply plugin: 'java'
         project.apply plugin: LombokPlugin.NAME
-        configuration = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
     }
 
     /**

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskIntegrationTest.groovy
@@ -31,7 +31,7 @@ class DelombokTaskIntegrationTest extends AbstractIntegrationTest {
         and:
         buildFile << """
             dependencies {
-                compile 'org.slf4j:slf4j-api:1.7.12'
+                implementation 'org.slf4j:slf4j-api:1.7.12'
             }
 
             ${delombokTask()}

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskSpec.groovy
@@ -7,18 +7,18 @@ import org.gradle.api.plugins.JavaPlugin
  */
 class DelombokTaskSpec extends AbstractJavaExecTaskSpec {
 
-    def "delomok calls JavaExec"() {
+    def "delombok calls JavaExec"() {
         given: "a newly created DelombokTask"
         def task = project.task(type: DelombokTask, "delombok")
         def execAction = mockJavaExecAction(task)
-        def compile = project.configurations.getByName(JavaPlugin.COMPILE_CONFIGURATION_NAME)
+        def expectedClasspath = project.configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
 
         when: "task executes"
         task.exec()
 
         then: "Delombok main is called"
         1 * execAction.setMain('lombok.launch.Main')
-        1 * execAction.classpath(configuration, compile)
+        1 * execAction.classpath(expectedClasspath)
         1 * execAction.execute()
     }
 

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTaskSpec.groovy
@@ -1,4 +1,7 @@
 package io.franzbecker.gradle.lombok.task
+
+import io.franzbecker.gradle.lombok.LombokPlugin
+
 /**
  * Unit tests for {@link InstallLombokTask}.
  */
@@ -8,6 +11,7 @@ class InstallLombokTaskSpec extends AbstractJavaExecTaskSpec {
         given:
         InstallLombokTask task = project.tasks.getByName(InstallLombokTask.NAME)
         def execAction = mockJavaExecAction(task)
+        def expectedClasspath = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
 
         when:
         task.exec()
@@ -15,7 +19,7 @@ class InstallLombokTaskSpec extends AbstractJavaExecTaskSpec {
         then:
         1 * execAction.setMain('lombok.launch.Main')
         1 * execAction.setIgnoreExitValue(true)
-        1 * execAction.setClasspath(configuration)
+        1 * execAction.setClasspath(expectedClasspath)
         1 * execAction.execute()
     }
 


### PR DESCRIPTION
Resolves #68.

You can verify the broken original behaviour by [changing only the dependency declaration style](https://github.com/franzbecker/gradle-lombok/compare/master...chadlwilson:use-modern-implementation-deps?expand=1#diff-38220009d89863ce5fedfcec8eafdc71) in `DelombokTaskIntegrationTest.groovy` from `compile` -> `implementation` and running the test - you should see it failing.

**Changes**
Change the default classpath of the task to use `compileClasspath` which includes `compileOnly` and `implementation` dependencies, as well as the legacy `compile` dependency type. This will work out of the box for more people; declaring their dependencies with modern Gradle style.

**Testing**
* Ran test suite.
* Manually tested with local Maven dependency per `CONTRIBUTING.md`