### PR TITLE
Fix `DelombokTask` and `InstallLombokTask` under Gradle 6.4

### DIFF
--- a/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/DelombokTask.groovy
+++ b/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/DelombokTask.groovy
@@ -1,7 +1,8 @@
 package io.franzbecker.gradle.lombok.task
 
-import io.franzbecker.gradle.lombok.LombokPlugin
+
 import io.franzbecker.gradle.lombok.LombokPluginExtension
+import org.gradle.api.Task
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
@@ -21,14 +22,14 @@ class DelombokTask extends JavaExec {
     }
 
     @Override
-    void exec() {
-        // Retrieve extension and configuration
-        def extension = project.extensions.findByType(LombokPluginExtension)
-        def compile = project.configurations.getByName(compileConfigurationName)
+    Task configure(Closure closure) {
+        setMain(project.extensions.findByType(LombokPluginExtension).main)
+        return super.configure(closure)
+    }
 
-        // Configure JavaExec
-        setMain(extension.main)
-        classpath(compile)
+    @Override
+    void exec() {
+        classpath(project.configurations.getByName(compileConfigurationName))
         super.exec()
     }
 

--- a/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTask.groovy
+++ b/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTask.groovy
@@ -1,6 +1,7 @@
 package io.franzbecker.gradle.lombok.task
 import io.franzbecker.gradle.lombok.LombokPlugin
 import io.franzbecker.gradle.lombok.LombokPluginExtension
+import org.gradle.api.Task
 import org.gradle.api.tasks.JavaExec
 
 /**
@@ -11,16 +12,16 @@ class InstallLombokTask extends JavaExec {
     static final String NAME = "installLombok"
 
     @Override
+    Task configure(Closure closure) {
+        setMain(project.extensions.findByType(LombokPluginExtension).main)
+        return super.configure(closure)
+    }
+
+    @Override
     void exec() {
-        // Retrieve extension and configuration
-        def extension = project.extensions.findByType(LombokPluginExtension)
-        def configuration = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
-
         // Configure JavaExec
-        setMain(extension.main)
         setIgnoreExitValue(true)
-        setClasspath(configuration)
-
+        setClasspath(project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME))
         super.exec()
     }
 

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -35,6 +35,7 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         '4.2.1'       || 'build/classes/java'
         '4.7'         || 'build/classes/java'
         '5.4'         || 'build/classes/java'
+        '6.4'         || 'build/classes/java'
     }
 
 }

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/DelombokTaskSpec.groovy
@@ -14,6 +14,7 @@ class DelombokTaskSpec extends AbstractJavaExecTaskSpec {
         def expectedClasspath = project.configurations.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME)
 
         when: "task executes"
+        task.configure {}
         task.exec()
 
         then: "Delombok main is called"

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/InstallLombokTaskSpec.groovy
@@ -14,6 +14,7 @@ class InstallLombokTaskSpec extends AbstractJavaExecTaskSpec {
         def expectedClasspath = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
 
         when:
+        task.configure {}
         task.exec()
 
         then:


### PR DESCRIPTION
We are not allowed to call `setMain` during `exec` phase on `JavaExec` because it is now final due to being a `Property<String>` for [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) in `6.4`. See https://github.com/gradle/gradle/issues/12841

The tests assertions as left implemented here continue to work up until `6.3` but assertions would need to change for `6.4` as the value is no longer set on the mock; and has its own property.

Tested this approach works at runtime on `6.3` and `6.4` in any case - fixes #76