### PR TITLE
Add support for Gradle 7

### DIFF
--- a/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
+++ b/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/LombokPlugin.groovy
@@ -25,6 +25,7 @@ class LombokPlugin implements Plugin<Project> {
 
     static final String NAME = "io.franzbecker.gradle-lombok"
     static final String LOMBOK_CONFIGURATION_NAME = COMPILE_ONLY_CONFIGURATION_NAME
+    static final String VERIFY_LOMBOK_CLASSPATH_CONFIGURATION_NAME = COMPILE_CLASSPATH_CONFIGURATION_NAME
 
     @Override
     void apply(Project project) {

--- a/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/VerifyLombokTask.groovy
+++ b/gradle-lombok-plugin/src/main/groovy/io/franzbecker/gradle/lombok/task/VerifyLombokTask.groovy
@@ -23,7 +23,7 @@ class VerifyLombokTask extends DefaultTask {
     void verifyLombok() {
         // Retrieve extension and configuration
         def extension = project.extensions.findByType(LombokPluginExtension)
-        def configuration = project.configurations.getByName(LombokPlugin.LOMBOK_CONFIGURATION_NAME)
+        def configuration = project.configurations.getByName(LombokPlugin.VERIFY_LOMBOK_CLASSPATH_CONFIGURATION_NAME)
         verifyLombok(extension, configuration)
     }
 
@@ -45,10 +45,10 @@ class VerifyLombokTask extends DefaultTask {
     protected File getLombokJar(String lombokVersion, Configuration configuration) {
         // Retrieve file
         def lombokFileName = "lombok-${lombokVersion}.jar"
-        logger.debug("Searching for '${lombokFileName}' in dependencies of configuration '${LombokPlugin.LOMBOK_CONFIGURATION_NAME}'.")
+        logger.debug("Searching for '${lombokFileName}' in dependencies of configuration '${configuration.name}'.")
         def lombokJar = configuration.files.find { File file -> file.name == lombokFileName }
         if (!lombokJar) {
-            throw new ResourceException("Could not find '${lombokFileName}' in dependencies of configuration '${LombokPlugin.LOMBOK_CONFIGURATION_NAME}'.")
+            throw new ResourceException("Could not find '${lombokFileName}' in dependencies of configuration '${configuration.name}'.")
         }
         logger.debug("Found '${lombokJar}'.")
         return lombokJar

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/AbstractIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/AbstractIntegrationTest.groovy
@@ -76,10 +76,14 @@ abstract class AbstractIntegrationTest extends Specification {
     }
 
     protected void createSimpleTestCase() {
+        createSimpleTestCase("testCompile")
+    }
+
+    protected void createSimpleTestCase(String testConfigurationName) {
         // build configuration supporting JUnit
         buildFile << """
             dependencies {
-                testCompile 'junit:junit:4.12'
+                ${testConfigurationName} 'junit:junit:4.12'
             }
         """.stripIndent()
 

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -38,4 +38,26 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         '6.4'         || 'build/classes/java'
     }
 
+    def "Gradle #gradleVersion - can run verifyLombok"() {
+        given:
+        theGradleVersion = gradleVersion
+        createSimpleTestCase()
+
+        when: "calling gradle verifyLombok"
+        runBuild('verifyLombok')
+
+        then: "no exception is thrown"
+        noExceptionThrown()
+
+        where:
+        gradleVersion || classesPath
+        '2.12'        || 'build/classes'
+        '2.14.1'      || 'build/classes'
+        '3.5'         || 'build/classes'
+        '4.2.1'       || 'build/classes/java'
+        '4.7'         || 'build/classes/java'
+        '5.4'         || 'build/classes/java'
+        '6.4'         || 'build/classes/java'
+    }
+
 }

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/CompatibilityIntegrationTest.groovy
@@ -17,7 +17,7 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
     def "Gradle #gradleVersion - can compile and test @Data annotation"() {
         given:
         theGradleVersion = gradleVersion
-        createSimpleTestCase()
+        createSimpleTestCase(testConfigurationName)
 
         when: "calling gradle test"
         runBuild('test')
@@ -28,20 +28,22 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         new File(projectDir, "$classesPath/test/com/example/HelloWorldTest.class").exists()
 
         where:
-        gradleVersion || classesPath
-        '2.12'        || 'build/classes'
-        '2.14.1'      || 'build/classes'
-        '3.5'         || 'build/classes'
-        '4.2.1'       || 'build/classes/java'
-        '4.7'         || 'build/classes/java'
-        '5.4'         || 'build/classes/java'
-        '6.4'         || 'build/classes/java'
+        gradleVersion || classesPath          || testConfigurationName
+        '2.12'        || 'build/classes'      || 'testCompile'
+        '2.14.1'      || 'build/classes'      || 'testCompile'
+        '3.5'         || 'build/classes'      || 'testCompile'
+        '4.2.1'       || 'build/classes/java' || 'testCompile'
+        '4.7'         || 'build/classes/java' || 'testCompile'
+        '5.4'         || 'build/classes/java' || 'testCompile'
+        '6.4'         || 'build/classes/java' || 'testCompile'
+        '6.4'         || 'build/classes/java' || 'testImplementation'
+        '7.0'         || 'build/classes/java' || 'testImplementation'
     }
 
     def "Gradle #gradleVersion - can run verifyLombok"() {
         given:
         theGradleVersion = gradleVersion
-        createSimpleTestCase()
+        createSimpleTestCase(testConfigurationName)
 
         when: "calling gradle verifyLombok"
         runBuild('verifyLombok')
@@ -50,14 +52,15 @@ class CompatibilityIntegrationTest extends AbstractIntegrationTest {
         noExceptionThrown()
 
         where:
-        gradleVersion || classesPath
-        '2.12'        || 'build/classes'
-        '2.14.1'      || 'build/classes'
-        '3.5'         || 'build/classes'
-        '4.2.1'       || 'build/classes/java'
-        '4.7'         || 'build/classes/java'
-        '5.4'         || 'build/classes/java'
-        '6.4'         || 'build/classes/java'
+        gradleVersion || classesPath          || testConfigurationName
+        '2.12'        || 'build/classes'      || 'testCompile'
+        '2.14.1'      || 'build/classes'      || 'testCompile'
+        '3.5'         || 'build/classes'      || 'testCompile'
+        '4.2.1'       || 'build/classes/java' || 'testCompile'
+        '4.7'         || 'build/classes/java' || 'testCompile'
+        '5.4'         || 'build/classes/java' || 'testCompile'
+        '6.4'         || 'build/classes/java' || 'testCompile'
+        '7.0'         || 'build/classes/java' || 'testImplementation'
     }
 
 }

--- a/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/VerifyLombokTaskSpec.groovy
+++ b/gradle-lombok-plugin/src/test/groovy/io/franzbecker/gradle/lombok/task/VerifyLombokTaskSpec.groovy
@@ -26,6 +26,7 @@ class VerifyLombokTaskSpec extends Specification {
         project.apply plugin: LombokPlugin.NAME
         task = project.tasks.getByName(VerifyLombokTask.NAME)
         configuration.iterator() >> Mock(Iterator)
+        configuration.getName() >> LombokPlugin.VERIFY_LOMBOK_CLASSPATH_CONFIGURATION_NAME
     }
 
     def "Fails if Lombok JAR is not found"() {
@@ -37,7 +38,7 @@ class VerifyLombokTaskSpec extends Specification {
 
         then:
         GradleException e = thrown()
-        e.message == "Could not find 'lombok-${version}.jar' in dependencies of configuration 'compileOnly'."
+        e.message == "Could not find 'lombok-${version}.jar' in dependencies of configuration 'compileClasspath'."
     }
 
     def "Does not fail if file integrity is fulfilled"() {


### PR DESCRIPTION
Hi! The `:verifyLombok` task fails in Gradle 7 because the `compileOnly` configuration is [no longer resolvable](https://docs.gradle.org/7.2/userguide/java_library_plugin.html#sec:java_library_configurations_graph):

```
> Task :verifyLombok FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':verifyLombok'.
> Resolving dependency configuration 'compileOnly' is not allowed as it is defined as 'canBeResolved=false'.
  Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'compileOnly' should be resolved.
```

Instead, it appears that libraries and plugins should use the `compileClasspath` configuration to resolve dependencies - for example to retrieve a JAR file, as in the case of `VerifyLombok`.

Included here are a couple of tests that expose the issue and a fix for it. It seems like this maintains compatibility all the way back to Gradle 2. :slightly_smiling_face: